### PR TITLE
Allow double-quoted fields in S3 logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <github.global.server>github</github.global.server>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
+        <antlr-runtime.version>4.7.1</antlr-runtime.version>
     </properties>
 
     <dependencies>
@@ -28,7 +29,7 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.7</version>
+            <version>${antlr-runtime.version}</version>
         </dependency>
 
     </dependencies>
@@ -38,7 +39,7 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.5</version>
+                <version>${antlr-runtime.version}</version>
                 <executions>
                     <execution>
                         <id>antlr</id>

--- a/src/main/antlr4/S3Tokens.g4
+++ b/src/main/antlr4/S3Tokens.g4
@@ -12,6 +12,12 @@ value returns [String val]
 			$val = $val.substring(1, $val.length()-1);
 			$val = $val.replace("\\\"", "\""); // unescape the quotes
 		}
+	| DoubleQuotedValue
+		{
+			$val = $DoubleQuotedValue.text;
+			$val = $val.substring(2, $val.length()-2);
+			$val = $val.replace("\\\"\\\"", "\"\""); // unescape the quotes
+		}
 	;
 
 NoValue
@@ -28,6 +34,10 @@ DateValue
 
 QuotedValue
 	: '"' (ESCAPED_QUOTE | DELIM | ALLOWED_CHAR)* '"'
+	;
+
+DoubleQuotedValue
+	: '""' (ESCAPED_QUOTE | DELIM | ALLOWED_CHAR)* '""'
 	;
 
 LINEBREAK

--- a/src/test/java/com/hiramsoft/commons/jsalparser/S3LogTest.java
+++ b/src/test/java/com/hiramsoft/commons/jsalparser/S3LogTest.java
@@ -98,25 +98,40 @@ public class S3LogTest
 
 	public void testSynopsis1() throws IOException
 	{
+		long TenMegabytes = 10000000L;
 		String content = "1f000000000c6c88eb9dd89c000000000b35b0000000a5 www.example.com [27/Aug/2014:20:20:05 +0000] 192.168.0.1 - BFE596E2F4D94C8F WEBSITE.GET.OBJECT media/example.jpg \"GET /media/example.jpg HTTP/1.1\" 304 - - 27553 202 - \"http://www.example.com/page.html\" \"Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0 Mobile/11D257 Safari/9537.53\" -";
 		List<S3LogEntry> entries = JSalParser.parseS3Log(content);
+		assertEquals(1, entries.size());
+		S3LogEntry entry = entries.get(0);
 
-		long TenMegabytes = 10000000L;
+		// Notice how the numbers are numbers, no additional parsing needed
+		if(entry.getObjectSize() > TenMegabytes)
+		{
+			System.out.println(entry.getTime());
 
-		for(int i=0;i<entries.size();i++) {
-			S3LogEntry entry = entries.get(i);
-
-			// Notice how the numbers are numbers, no additional parsing needed
-			if(entry.getObjectSize() > TenMegabytes)
-			{
-				System.out.println(entry.getTime());
-
-				// getTime() returns a JODA DateTime object,
-				// so Java prints:
-				// 2014-08-27T20:20:05.000+00:00
-			}
+			// getTime() returns a JODA DateTime object,
+			// so Java prints:
+			// 2014-08-27T20:20:05.000+00:00
 		}
+	}
 
-		assertEquals(entries.size(), 1);
+	// Double quoted user agent
+	public void testSynopsis2()
+	{
+		String content = "1f000000000c6c88eb9dd89c000000000b35b0000000a5 www.example.com [27/Aug/2014:20:20:05 +0000] 192.168.0.1 - BFE596E2F4D94C8F WEBSITE.GET.OBJECT media/example.jpg \"GET /media/example.jpg HTTP/1.1\" 304 - - 27553 202 - \"http://www.example.com/page.html\" \"\"Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0 Mobile/11D257 Safari/9537.53\"\" -";
+		List<S3LogEntry> entries = JSalParser.parseS3Log(content);
+		assertEquals(1, entries.size());
+		S3LogEntry entry = entries.get(0);
+		assertEquals("Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0 Mobile/11D257 Safari/9537.53", entry.getUserAgent());
+	}
+
+	// Double quoted empty-value user agent
+	public void testSynopsis3()
+	{
+		String content = "1f000000000c6c88eb9dd89c000000000b35b0000000a5 www.example.com [27/Aug/2014:20:20:05 +0000] 192.168.0.1 - BFE596E2F4D94C8F WEBSITE.GET.OBJECT media/example.jpg \"GET /media/example.jpg HTTP/1.1\" 304 - - 27553 202 - \"http://www.example.com/page.html\" \"\"\"\" -";
+		List<S3LogEntry> entries = JSalParser.parseS3Log(content);
+		assertEquals(1, entries.size());
+		S3LogEntry entry = entries.get(0);
+		assertEquals("", entry.getUserAgent());
 	}
 }


### PR DESCRIPTION
The PR is a result of noticing some S3 log entries where the User Agent field was wrapped by double quotes instead of only one quote. This has happened on a production system, but with a very low impact (~1:10M parsed log entries).
The library simply failed to parse the field, leaving it null, but it had the side-effect of generating a new log entry with all fields set to null or empty value.

List of changes:
* Adds a new token for double quotes and use it as last resort when parsing a field.
* Some tests for this specific case.
* Bump antlr version.